### PR TITLE
Update UnsupportedChainIdError in Part 1 of Section 4 (JSDAO)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,8 @@ import { ethers } from "ethers";
 import { useWeb3 } from "@3rdweb/hooks";
 import { ThirdwebSDK } from "@3rdweb/sdk";
 
+import { UnsupportedChainIdError } from "@web3-react/core";
+
 const sdk = new ThirdwebSDK("rinkeby");
 
 const bundleDropModule = sdk.getBundleDropModule(
@@ -166,7 +168,7 @@ const App = () => {
       });
   }, [hasClaimedNFT, proposals, address]);
 
-  if (error && error.name === "UnsupportedChainIdError") {
+  if (error instanceof UnsupportedChainIdError ) {
     return (
       <div className="unsupported-network">
         <h2>Please connect to Rinkeby</h2>


### PR DESCRIPTION
This is an edit to correctly process the error that occurs when an Unsupported chain (anything except Rinkeby) is connected to the dapp.